### PR TITLE
cli: add shebang and mark as executable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import logging
 from typing import List, Dict, Any, Set


### PR DESCRIPTION
this allows people to run `./cli.py ...` instead of needing to run `python cli.py ...`, so long as they run *nix and have `python` in their path