### PR TITLE
feat-285: Populate user config from public stashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,17 @@ You can always check them out via `python cli.py --help`.
 
 ```
 ❯ python cli.py --help
-usage: cli.py [-h] [--league LEAGUE] [--currency CURRENCY] [--limit LIMIT] [--fullbulk] [--nofilter] [--debug] [--config CONFIG]
+usage: cli.py [-h] [--league LEAGUE] [--currency CURRENCY] [--limit LIMIT] [--fullbulk] [--nofilter] [--debug] [--config CONFIG] [{pathfinding,sync}]
 
 CLI interface for PathFinder
 
+positional arguments:
+  {pathfinding,sync}   Specifies what subcommand to run: 1. pathfinding: Find profitable conversion paths (default). 2. sync: Sync your public stashes into your
+                       config file.
+
 optional arguments:
   -h, --help           show this help message and exit
-  --league LEAGUE      League specifier, ie. 'Scourge', 'Hardcore Scourge' or 'Flashback Event (BRE001)'. Defaults to 'Scourge'.
+  --league LEAGUE      League specifier, ie. 'Synthesis', 'Hardcore Synthesis' or 'Flashback Event (BRE001)'. Defaults to 'Scourge'.
   --currency CURRENCY  Full name of currency to flip, ie. 'Cartographer's Chisel, or 'Chaos Orb'. Defaults to all currencies.
   --limit LIMIT        Limit the number of displayed conversions. Defaults to 5.
   --fullbulk           Use all supported bulk items
@@ -87,8 +91,10 @@ optional arguments:
   --config CONFIG      Specify your config file path
 ```
 
-By default, we use both [pathofexile.com/trade](https://pathofexile.com/trade/exchange)
-and [poe.trade](http://poe.trade) in parallel to fetch trade offers.
+<!--By default, we use both [pathofexile.com/trade](https://pathofexile.com/trade/exchange)
+and [poe.trade](http://poe.trade) in parallel to fetch trade offers.-->
+
+At the moment we solely support [poe.trade](http://poe.trade) to fetch trade offers.
 
 Options `--fullbulk` and `--nofilter` bypass the configuration files and extend
 the set of item pairs that is used to collect data for.
@@ -101,7 +107,7 @@ The configuration file lets you define the following:
 
 - Item trading paths
 - Stock requirements when buying & selling
-- Your trading capital
+- Sync your trading capital via the `sync` command into your local configuration file
 - [Blacklisting traders](#blacklisting-traders)
 
 If you did not configure a custom configuration file, the default settings in
@@ -110,6 +116,21 @@ Blacklisting traders is done separately, see [blacklisting traders](#blacklistin
 
 The default configuration takes care for you of the first two points, but you
 are free to customize.
+
+### Sync Trading Capital
+
+You can use `python cli.py --league <LEAGUE> sync` to seemlessly sync your trading capital from your
+public stash tabs into your specified configuration file.
+
+For this you need to specify your account name and your `POESESSID` (a cookie value that PoE uses
+to identify your account, see [here](https://cptpingu.github.io/poe-stash/poesessid.html)
+for a guide on how to retrieve it) in your respective configuration file.
+
+If you have no configuration file yet, feel free to copy `config/config.default.json` to `config/config.json`
+so you can get started.
+The file `config.default.json` is not usable with this feature, so you have to bring your own for this.
+
+Running the above command should then work fine.
 
 ### Example Configuration
 

--- a/cli.py
+++ b/cli.py
@@ -1,77 +1,71 @@
 #!/usr/bin/env python
-import argparse
-import logging
 
-from src.commons import (init_logger, LEAGUE_NAMES, load_excluded_traders,
-                         unique_conversions_by_trader_name)
+import argparse
+from typing import Union
+from commands.pathfinder import execute_pathfinding
+from commands.sync import execute_sync
+
+from src.commons import (
+    init_logger,
+    LEAGUE_NAMES,
+    load_excluded_traders,
+)
 from src.config.user_config import UserConfig
 from src.core.backends.poeofficial import PoeOfficial
-from src.pathfinder import PathFinder
 from src.trading.items import ItemList
 
-
-def log_conversions(conversions, limit):
-    for c in conversions[:limit]:
-        log_conversion(c)
-
-
-def log_conversion(c):
-    logging.info("\t{} {} -> {} {}: {} {}".format(c["starting"], c["from"],
-                                                  c["ending"], c["to"],
-                                                  c["winnings"], c["to"]))
-    for t in c["transactions"]:
-        logging.info(
-            "\t\t@{} Hi, I'd like to buy your {} {} for {} {} in {}. ({}x)".
-            format(
-                t.contact_ign,
-                t.received,
-                t.want,
-                t.paid,
-                t.have,
-                t.league,
-                t.conversion_rate,
-            ))
-    logging.info("\n")
-
-
 parser = argparse.ArgumentParser(description="CLI interface for PathFinder")
+
+parser.add_argument("command",
+                    default="pathfinding",
+                    choices=["pathfinding", "sync"],
+                    type=str,
+                    nargs="?",
+                    help="Specifies what subcommand to run:\n\n\
+    1. pathfinding: Find profitable conversion paths (default).\n\
+    2. sync: Sync your public stashes into your config file."),
 
 parser.add_argument(
     "--league",
     default=LEAGUE_NAMES[0],
     type=str,
-    help=
-    "League specifier, ie. 'Synthesis', 'Hardcore Synthesis' or 'Flashback Event (BRE001)'. Defaults to '{}'."
-    .format(LEAGUE_NAMES[0]),
+    help="""
+    League specifier, ie. 'Synthesis', 'Hardcore Synthesis' or 'Flashback Event (BRE001)'. 
+    Defaults to '{}'.""".format(LEAGUE_NAMES[0]),
 )
+
 parser.add_argument(
     "--currency",
     default="all",
-    # choices=cli_default_items,
     type=str,
     help=
-    "Full name of currency to flip, ie. 'Cartographer's Chisel, or 'Chaos Orb'. Defaults to all currencies.",
+    """Full name of currency to flip, ie. 'Cartographer's Chisel, or 'Chaos Orb'. 
+    Defaults to all currencies.""",
 )
+
 parser.add_argument(
     "--limit",
     default=5,
     type=int,
     help="Limit the number of displayed conversions. Defaults to 5.",
 )
+
 parser.add_argument(
     "--fullbulk",
     default=False,
     action="store_true",
     help="Use all supported bulk items",
 )
+
 parser.add_argument("--nofilter",
                     default=False,
                     action="store_true",
                     help="Disable item pair filters")
+
 parser.add_argument("--debug",
-                    default=None,
                     action="store_true",
                     help="Enables debug logging")
+
 parser.add_argument("--config",
                     default=None,
                     type=str,
@@ -79,41 +73,35 @@ parser.add_argument("--config",
 
 arguments = parser.parse_args()
 init_logger(arguments.debug)
-item_list = ItemList.load_from_file()
-backend = PoeOfficial(item_list)
 
-league = arguments.league
-currency = arguments.currency
-limit = arguments.limit
-fullbulk = arguments.fullbulk
-no_filter = arguments.nofilter
+# global arguments
+command: str = arguments.command
+league: str = arguments.league
+config_file_path: Union[str, None] = arguments.config
+
+# arguments related to pathfinding
+currency: Union[str, None] = arguments.currency
+limit: Union[int, None] = arguments.limit
+fullbulk: bool = arguments.fullbulk
+no_filter: bool = arguments.nofilter
 config = {"fullbulk": fullbulk}
-config_file_path = arguments.config
 
-# Load excluded trader list
-excluded_traders = load_excluded_traders()
+if command is "pathfinding":
+    # Load excluded trader list
+    excluded_traders = load_excluded_traders()
 
-# Load user config
-user_config = UserConfig.from_file(config_file_path)
+    # Load user config
+    user_config = UserConfig.from_file(config_file_path)
 
-# Load item pairs
-item_pairs = item_list.get_item_list_for_backend(
-    backend, config) if no_filter else user_config.get_item_pairs()
+    # Load item pairs
+    item_list = ItemList.load_from_file()
+    backend = PoeOfficial(item_list)
+    item_pairs = item_list.get_item_list_for_backend(
+        backend, config) if no_filter else user_config.get_item_pairs()
 
-p = PathFinder(league, item_pairs, user_config, excluded_traders)
-p.run(2)
-
-try:
-    logging.info("\n")
-    if currency == "all":
-        for c in p.graph.keys():
-            conversions = unique_conversions_by_trader_name(p.results[c])
-            log_conversions(conversions, limit)
-    else:
-        conversions = unique_conversions_by_trader_name(p.results[currency])
-        log_conversions(conversions, limit)
-
-except KeyError:
-    logging.warning(
-        "Could not find any profitable conversions for {} in {}".format(
-            currency, league))
+    execute_pathfinding(currency, league, limit, item_pairs, user_config,
+                        excluded_traders)
+elif command is "sync":
+    execute_sync()
+else:
+    raise Exception("Command {} does not exist".format(command))

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import logging
 from typing import Union
 from src.commands.pathfinder import execute_pathfinding
 from src.commands.sync import execute_sync
@@ -87,8 +88,12 @@ if command == "pathfinding":
     no_filter: bool = arguments.nofilter
     config = {"fullbulk": fullbulk}
 
-    # Load user config
-    user_config = UserConfig.from_file(config_file_path, True)
+    try:
+        # Load user config
+        user_config = UserConfig.from_file(config_file_path, True)
+    except Exception as ex:
+        logging.error(f"Error: {ex.args[0]}")
+        exit(1)
 
     # Load excluded trader list
     excluded_traders = load_excluded_traders()

--- a/cli.py
+++ b/cli.py
@@ -79,9 +79,6 @@ command: str = arguments.command
 league: str = arguments.league
 config_file_path: Union[str, None] = arguments.config
 
-# Load user config
-user_config = UserConfig.from_file(config_file_path)
-
 if command == "pathfinding":
     # arguments related to pathfinding
     currency: Union[str, None] = arguments.currency
@@ -89,6 +86,9 @@ if command == "pathfinding":
     fullbulk: bool = arguments.fullbulk
     no_filter: bool = arguments.nofilter
     config = {"fullbulk": fullbulk}
+
+    # Load user config
+    user_config = UserConfig.from_file(config_file_path, True)
 
     # Load excluded trader list
     excluded_traders = load_excluded_traders()
@@ -102,6 +102,6 @@ if command == "pathfinding":
     execute_pathfinding(currency, league, limit, item_pairs, user_config,
                         excluded_traders)
 elif command == "sync":
-    execute_sync(user_config, league)
+    execute_sync(config_file_path, league)
 else:
     raise Exception("Command {} does not exist".format(command))

--- a/cli.py
+++ b/cli.py
@@ -102,6 +102,6 @@ if command == "pathfinding":
     execute_pathfinding(currency, league, limit, item_pairs, user_config,
                         excluded_traders)
 elif command == "sync":
-    execute_sync(user_config)
+    execute_sync(user_config, league)
 else:
     raise Exception("Command {} does not exist".format(command))

--- a/cli.py
+++ b/cli.py
@@ -2,8 +2,8 @@
 
 import argparse
 from typing import Union
-from commands.pathfinder import execute_pathfinding
-from commands.sync import execute_sync
+from src.commands.pathfinder import execute_pathfinding
+from src.commands.sync import execute_sync
 
 from src.commons import (
     init_logger,
@@ -79,19 +79,19 @@ command: str = arguments.command
 league: str = arguments.league
 config_file_path: Union[str, None] = arguments.config
 
-# arguments related to pathfinding
-currency: Union[str, None] = arguments.currency
-limit: Union[int, None] = arguments.limit
-fullbulk: bool = arguments.fullbulk
-no_filter: bool = arguments.nofilter
-config = {"fullbulk": fullbulk}
+# Load user config
+user_config = UserConfig.from_file(config_file_path)
 
-if command is "pathfinding":
+if command == "pathfinding":
+    # arguments related to pathfinding
+    currency: Union[str, None] = arguments.currency
+    limit: Union[int, None] = arguments.limit
+    fullbulk: bool = arguments.fullbulk
+    no_filter: bool = arguments.nofilter
+    config = {"fullbulk": fullbulk}
+
     # Load excluded trader list
     excluded_traders = load_excluded_traders()
-
-    # Load user config
-    user_config = UserConfig.from_file(config_file_path)
 
     # Load item pairs
     item_list = ItemList.load_from_file()
@@ -101,7 +101,7 @@ if command is "pathfinding":
 
     execute_pathfinding(currency, league, limit, item_pairs, user_config,
                         excluded_traders)
-elif command is "sync":
-    execute_sync()
+elif command == "sync":
+    execute_sync(user_config)
 else:
     raise Exception("Command {} does not exist".format(command))

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -1,5 +1,7 @@
 {
   "version": 1,
+  "POESESSID": null,
+  "accountName": null,
   "assets": {},
   "trading": {
     "Aetheric Fossil": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -222,7 +222,7 @@ unicode_backport = ["unicodedata2"]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -742,14 +742,14 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "packaging"
-version = "21.2"
+version = "21.0"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2,<3"
+pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pandas"
@@ -843,7 +843,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prometheus-client"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python client for the Prometheus monitoring system."
 category = "dev"
 optional = false
@@ -930,11 +930,14 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.3"
 description = "Python parsing module"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyrsistent"
@@ -1142,6 +1145,22 @@ optional = false
 python-versions = ">= 3.5"
 
 [[package]]
+name = "tqdm"
+version = "4.62.3"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+telegram = ["requests"]
+
+[[package]]
 name = "traitlets"
 version = "5.1.1"
 description = "Traitlets Python configuration system"
@@ -1241,7 +1260,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "221bd2ef4f55c393b073ac8bfd00f407da6588239755e8134d8e02a20da481af"
+content-hash = "893af56c9deef846f724bf9da2f393d0162c8b5aa0be8df8591a1d58f3b28f6a"
 
 [metadata.files]
 aiohttp = [
@@ -1846,8 +1865,8 @@ numpy = [
     {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
 ]
 packaging = [
-    {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
-    {file = "packaging-21.2.tar.gz", hash = "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966"},
+    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
+    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pandas = [
     {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
@@ -1943,8 +1962,8 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 prometheus-client = [
-    {file = "prometheus_client-0.11.0-py2.py3-none-any.whl", hash = "sha256:b014bc76815eb1399da8ce5fc84b7717a3e63652b0c0f8804092c9363acab1b2"},
-    {file = "prometheus_client-0.11.0.tar.gz", hash = "sha256:3a8baade6cb80bcfe43297e33e7623f3118d660d41387593758e2fb1ea173a86"},
+    {file = "prometheus_client-0.12.0-py2.py3-none-any.whl", hash = "sha256:317453ebabff0a1b02df7f708efbab21e3489e7072b61cb6957230dd004a0af0"},
+    {file = "prometheus_client-0.12.0.tar.gz", hash = "sha256:1b12ba48cee33b9b0b9de64a1047cbd3c5f2d0ab6ebcead7ddda613a750ec3c5"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.21-py3-none-any.whl", hash = "sha256:62b3d3ea5a3ccee94dc1aac018279cf64866a76837156ebe159b981c42dd20a8"},
@@ -1979,8 +1998,8 @@ pylint = [
     {file = "pylint-2.11.1.tar.gz", hash = "sha256:2c9843fff1a88ca0ad98a256806c82c5a8f86086e7ccbdb93297d86c3f90c436"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.3-py3-none-any.whl", hash = "sha256:f8d3fe9fc404576c5164f0f0c4e382c96b85265e023c409c43d48f65da9d60d0"},
+    {file = "pyparsing-3.0.3.tar.gz", hash = "sha256:9e3511118010f112a4b4b435ae50e1eaa610cda191acb9e421d60cf5fde83455"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
@@ -2174,6 +2193,10 @@ tornado = [
     {file = "tornado-6.1-cp39-cp39-win32.whl", hash = "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c"},
     {file = "tornado-6.1-cp39-cp39-win_amd64.whl", hash = "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4"},
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
+]
+tqdm = [
+    {file = "tqdm-4.62.3-py2.py3-none-any.whl", hash = "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c"},
+    {file = "tqdm-4.62.3.tar.gz", hash = "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"},
 ]
 traitlets = [
     {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ jsonpickle = "^1.5.0"
 deserialize = "^1.8.0"
 cattrs = "^1.1.2"
 aiolimiter = "^1.0.0"
+tqdm = "^4.62.3"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.790"

--- a/src/commands/pathfinder.py
+++ b/src/commands/pathfinder.py
@@ -1,7 +1,7 @@
 import logging
-from commons import unique_conversions_by_trader_name
+from src.commons import unique_conversions_by_trader_name
 
-from pathfinder import PathFinder
+from src.pathfinder import PathFinder
 
 
 def log_conversions(conversions, limit):

--- a/src/commands/pathfinder.py
+++ b/src/commands/pathfinder.py
@@ -1,0 +1,50 @@
+import logging
+from commons import unique_conversions_by_trader_name
+
+from pathfinder import PathFinder
+
+
+def log_conversions(conversions, limit):
+    for c in conversions[:limit]:
+        log_conversion(c)
+
+
+def log_conversion(c):
+    logging.info("\t{} {} -> {} {}: {} {}".format(c["starting"], c["from"],
+                                                  c["ending"], c["to"],
+                                                  c["winnings"], c["to"]))
+    for t in c["transactions"]:
+        logging.info(
+            "\t\t@{} Hi, I'd like to buy your {} {} for {} {} in {}. ({}x)".
+            format(
+                t.contact_ign,
+                t.received,
+                t.want,
+                t.paid,
+                t.have,
+                t.league,
+                t.conversion_rate,
+            ))
+    logging.info("\n")
+
+
+def execute_pathfinding(currency: str, league: str, limit: int, item_pairs,
+                        user_config, excluded_traders):
+    p = PathFinder(league, item_pairs, user_config, excluded_traders)
+    p.run(2)
+
+    try:
+        logging.info("\n")
+        if currency == "all":
+            for c in p.graph.keys():
+                conversions = unique_conversions_by_trader_name(p.results[c])
+                log_conversions(conversions, limit)
+        else:
+            conversions = unique_conversions_by_trader_name(
+                p.results[currency])
+            log_conversions(conversions, limit)
+
+    except KeyError:
+        logging.warning(
+            "Could not find any profitable conversions for {} in {}".format(
+                currency, league))

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -1,13 +1,17 @@
 import logging
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 from src.config.user_config import UserConfig
 from tqdm import tqdm
 
 
-def execute_sync(user_config: UserConfig, league: str):
+def execute_sync(config_file_path: Optional[str], league: str):
+    # Load user config
+    config_file_path = UserConfig.get_file_path(config_file_path)
+    user_config = UserConfig.from_file(config_file_path, False)
+
     if user_config.account_name == None:
         raise Exception("Missing accountName in config file")
     if user_config.poe_session_id == None:

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -1,0 +1,2 @@
+def execute_sync():
+    pass

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -1,8 +1,10 @@
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+import time
+from typing import Any, Dict, List, Tuple
 
 import requests
 from src.config.user_config import UserConfig
+from tqdm import tqdm
 
 
 def execute_sync(user_config: UserConfig, league: str):
@@ -11,52 +13,75 @@ def execute_sync(user_config: UserConfig, league: str):
     if user_config.poe_session_id == None:
         raise Exception("Missing POESESSID in config file")
 
-    print(user_config.poe_session_id)
-    print(user_config.account_name)
+    logging.info(
+        f"Starting sync for account {user_config.account_name} in league {league}"
+    )
 
-    headers = {
-        "Cookie": "POESESSID={}".format(user_config.poe_session_id),
-        "User-Agent": "curl/7.76.1"
-    }
+    session = requests.Session()
+    session.headers.update({
+        "Cookie":
+        "POESESSID={}".format(user_config.poe_session_id),
+        "User-Agent":
+        "curl/7.76.1"
+    })
+
+    stash_tabs = fetch_stash_tabs(session, league, user_config.account_name)
+    public_tab_indices = find_public_stashes(stash_tabs)
+    logging.info("Found {} public stash tabs".format(len(public_tab_indices)))
+
+    if len(public_tab_indices) == 0:
+        logging.warn("No public stash tabs to sync with were found")
+        return
+
+    items: Dict[str, int] = dict()
+
+    for tab_idx in tqdm(public_tab_indices):
+        stash_items = fetch_stash_tab_items(session, league,
+                                            user_config.account_name, tab_idx)
+        aggregate(items, stash_items)
+        time.sleep(1)
+
+    logging.info(f"Successfully synced {len(items)} items")
+
+
+def aggregate(acc: Dict[str, int], stash_items: List[Tuple[str, int]]) -> dict:
+    for item_name, stack_size in stash_items:
+        acc.update({item_name: acc.get(item_name, 0) + stack_size})
+
+    return acc
+
+
+def fetch_stash_tabs(session: requests.Session, league: str,
+                     account_name: str) -> List[Dict[str, Any]]:
     url = "https://www.pathofexile.com/character-window/get-stash-items"
     params = {
         "league": league,
-        "accountName": user_config.account_name,
-        "tabs": 1,  # this *should* be the currency stash tab
+        "accountName": account_name,
+        "tabs": 1,  # this should give a list of all tabs
     }
+    return session.get(url, params=params).json()["tabs"]
 
-    # TODO the currency stash tab is somewhat irrelevant, because users
-    # would want the tool to find the stuff in the public premium stash tabs (+ currency stash tab maybe)
-    #
-    # Do some thinking here
-    response = requests.get(url, params=params, headers=headers).json()
 
-    currency_stash_idx = find_currency_stash(response["tabs"])
-    logging.info(
-        "Found Currency Stash Tab at index {}".format(currency_stash_idx))
-
-    if currency_stash_idx is None:
-        logging.info("No currency stash tab to sync with was found")
-        return
-
+def fetch_stash_tab_items(session: requests.Session, league: str,
+                          account_name: str,
+                          tab_idx: int) -> List[Tuple[str, int]]:
     url = "https://www.pathofexile.com/character-window/get-stash-items"
-    response = requests.get(url,
-                            params={
-                                "league": league,
-                                "accountName": user_config.account_name,
-                                "tabIndex": currency_stash_idx
-                            },
-                            headers=headers).json()
 
-    synced_items = parse_items(response["items"])
-    logging.info(synced_items)
+    response = session.get(
+        url,
+        params={
+            "league": league,
+            "accountName": account_name,
+            "tabIndex": tab_idx
+        },
+    )
+
+    synced_items = parse_items(response.json()["items"])
+    return synced_items
 
 
-def find_currency_stash(json: List[Dict[str, Any]]) -> Optional[int]:
-    for stash in json:
-        if stash["type"] == "CurrencyStash":
-            return stash["i"]
-    return None
+def find_public_stashes(json: List[Dict[str, Any]]) -> List[int]:
+    return [stash["i"] for stash in json if stash["type"] == "PremiumStash"]
 
 
 # TODO maybe we have to check back the items found here with the list of
@@ -65,15 +90,7 @@ def parse_items(json: List[Dict[str, Any]]) -> List[Tuple[str, int]]:
     """
     Parses a list of tuples of <type_line, stack_size>.
     """
-    pairs = []
+    stackable_items = [(item.get("typeLine"), item.get("stackSize"))
+                       for item in json if item.get("stackSize") != None]
 
-    for item in json:
-        p = (item.get("typeLine"), item.get("stackSize"))
-
-        # Skip non-stackable items, eg. armour in the crafting bench
-        if p[1] is None:
-            continue
-
-        pairs.append(p)
-
-    return pairs
+    return stackable_items

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -45,6 +45,10 @@ def execute_sync(config_file_path: Optional[str], league: str):
         aggregate(items, stash_items)
         time.sleep(1)
 
+    for item_name, stack_size in items.items():
+        user_config.set_asset_quantity(item_name, stack_size)
+
+    user_config.save(config_file_path)
     logging.info(f"Successfully synced {len(items)} items")
 
 

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -1,7 +1,11 @@
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
 from src.config.user_config import UserConfig
 
 
-def execute_sync(user_config: UserConfig):
+def execute_sync(user_config: UserConfig, league: str):
     if user_config.account_name == None:
         raise Exception("Missing accountName in config file")
     if user_config.poe_session_id == None:
@@ -9,3 +13,67 @@ def execute_sync(user_config: UserConfig):
 
     print(user_config.poe_session_id)
     print(user_config.account_name)
+
+    headers = {
+        "Cookie": "POESESSID={}".format(user_config.poe_session_id),
+        "User-Agent": "curl/7.76.1"
+    }
+    url = "https://www.pathofexile.com/character-window/get-stash-items"
+    params = {
+        "league": league,
+        "accountName": user_config.account_name,
+        "tabs": 1,  # this *should* be the currency stash tab
+    }
+
+    # TODO the currency stash tab is somewhat irrelevant, because users
+    # would want the tool to find the stuff in the public premium stash tabs (+ currency stash tab maybe)
+    #
+    # Do some thinking here
+    response = requests.get(url, params=params, headers=headers).json()
+
+    currency_stash_idx = find_currency_stash(response["tabs"])
+    logging.info(
+        "Found Currency Stash Tab at index {}".format(currency_stash_idx))
+
+    if currency_stash_idx is None:
+        logging.info("No currency stash tab to sync with was found")
+        return
+
+    url = "https://www.pathofexile.com/character-window/get-stash-items"
+    response = requests.get(url,
+                            params={
+                                "league": league,
+                                "accountName": user_config.account_name,
+                                "tabIndex": currency_stash_idx
+                            },
+                            headers=headers).json()
+
+    synced_items = parse_items(response["items"])
+    logging.info(synced_items)
+
+
+def find_currency_stash(json: List[Dict[str, Any]]) -> Optional[int]:
+    for stash in json:
+        if stash["type"] == "CurrencyStash":
+            return stash["i"]
+    return None
+
+
+# TODO maybe we have to check back the items found here with the list of
+# supported items in the item_list module
+def parse_items(json: List[Dict[str, Any]]) -> List[Tuple[str, int]]:
+    """
+    Parses a list of tuples of <type_line, stack_size>.
+    """
+    pairs = []
+
+    for item in json:
+        p = (item.get("typeLine"), item.get("stackSize"))
+
+        # Skip non-stackable items, eg. armour in the crafting bench
+        if p[1] is None:
+            continue
+
+        pairs.append(p)
+
+    return pairs

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -1,2 +1,11 @@
-def execute_sync():
-    pass
+from src.config.user_config import UserConfig
+
+
+def execute_sync(user_config: UserConfig):
+    if user_config.account_name == None:
+        raise Exception("Missing accountName in config file")
+    if user_config.poe_session_id == None:
+        raise Exception("Missing POESESSID in config file")
+
+    print(user_config.poe_session_id)
+    print(user_config.account_name)

--- a/src/commands/sync.py
+++ b/src/commands/sync.py
@@ -8,9 +8,13 @@ from tqdm import tqdm
 
 
 def execute_sync(config_file_path: Optional[str], league: str):
-    # Load user config
-    config_file_path = UserConfig.get_file_path(config_file_path)
-    user_config = UserConfig.from_file(config_file_path, False)
+    try:
+        # Load user config
+        config_file_path = UserConfig.get_file_path(config_file_path)
+        user_config = UserConfig.from_file(config_file_path, False)
+    except Exception as ex:
+        logging.error(f"Error: {ex.args[0]}")
+        exit(1)
 
     if user_config.account_name == None:
         raise Exception("Missing accountName in config file")

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -58,6 +58,11 @@ class UserConfig:
         self.poe_session_id = poe_session_id
         self.stack_sizes = StackSizeHelper()
 
+    def save(self, file_path: str):
+        serialized = UserConfigSchema().dumps(self, indent=2, sort_keys=True)
+        with open(file_path, "w") as f:
+            f.write(serialized)
+
     def get_maximum_trade_volume_for_item(self, item: str) -> int:
         """
         Returns the maximum amount of @item you want to or can trade with.
@@ -126,15 +131,21 @@ class UserConfig:
 
         return item_pairs
 
+    def set_asset_quantity(self, asset: str, quantity: int):
+        self.assets.update({asset: quantity})
+
     @staticmethod
-    def from_file(file_path: Optional[str] = None) -> UserConfig:
-        if file_path is None:
-            file_path = DEFAULT_CONFIG_FILE_PATH
+    def get_file_path(file_path: Optional[str]) -> str:
+        file_path = file_path if file_path != None else DEFAULT_CONFIG_FILE_PATH
+        return pathlib.Path(file_path).resolve()
 
-        path = pathlib.Path(file_path).resolve()
+    @staticmethod
+    def from_file(file_path: Optional[str],
+                  allow_default_config: bool = False) -> UserConfig:
+        path = UserConfig.get_file_path(file_path)
 
-        # Default back to default config file
-        if not path.is_file():
+        # Default back to default config file if allowed
+        if not path.is_file() and allow_default_config:
             path = pathlib.Path(DEFAULT_CONFIG_DEFAULT_FILE_PATH).resolve()
 
         try:

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -42,8 +42,8 @@ class UserConfig:
     assets: AssetConfig
     trading: TradingConfig
     stack_sizes: StackSizeHelper
-    poe_session_id: Union[str | None]
-    account_name: Union[str | None]
+    poe_session_id: Union[str, None]
+    account_name: Union[str, None]
 
     def __init__(self,
                  version: int,
@@ -136,7 +136,7 @@ class UserConfig:
 
     @staticmethod
     def get_file_path(file_path: Optional[str]) -> str:
-        file_path = file_path if file_path != None else DEFAULT_CONFIG_FILE_PATH
+        file_path = file_path if file_path is not None else DEFAULT_CONFIG_FILE_PATH
         return pathlib.Path(file_path).resolve()
 
     @staticmethod

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -17,12 +17,20 @@ INT_INFINITY = 1_000_000
 
 
 class UserConfigSchema(Schema):
-    version = fields.Int()
-    assets = fields.Dict(keys=fields.Str(), values=fields.Int())
+    version = fields.Int(required=True)
+    assets = fields.Dict(keys=fields.Str(),
+                         values=fields.Int(),
+                         dump_default={})
     trading = fields.Dict(keys=fields.Str(),
                           values=fields.Nested(TradingConfigItemSchema,
                                                allow_none=True),
-                          allow_none=True)
+                          dump_default={})
+    account_name = fields.Str(data_key="accountName",
+                              allow_none=True,
+                              dump_default=None)
+    poe_session_id = fields.Str(data_key="POESESSID",
+                                allow_none=True,
+                                dump_default=None)
 
     @post_load
     def make_user_config(self, data, many, partial):
@@ -34,12 +42,20 @@ class UserConfig:
     assets: AssetConfig
     trading: TradingConfig
     stack_sizes: StackSizeHelper
+    poe_session_id: str
+    account_name: str
 
-    def __init__(self, version: int, assets: AssetConfig,
-                 trading: TradingConfig):
+    def __init__(self,
+                 version: int,
+                 assets: AssetConfig,
+                 trading: TradingConfig,
+                 account_name: str = None,
+                 poe_session_id: str = None):
         self.version = version
         self.assets = assets
         self.trading = trading
+        self.account_name = account_name
+        self.poe_session_id = poe_session_id
         self.stack_sizes = StackSizeHelper()
 
     def get_maximum_trade_volume_for_item(self, item: str) -> int:

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -154,7 +154,9 @@ class UserConfig:
                 data = json.loads(f.read())
                 return UserConfigSchema().load(data)
         except OSError:
-            raise Exception("The specified config file path does not exist")
+            raise Exception(
+                "The specified config file path does not exist or cannot be read"
+            )
 
     @staticmethod
     def from_raw(raw: str) -> UserConfig:

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import pathlib
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from marshmallow import Schema, fields, post_load
 from src.config.parser import (AssetConfig, TradingConfig, TradingConfigItem,
@@ -42,8 +42,8 @@ class UserConfig:
     assets: AssetConfig
     trading: TradingConfig
     stack_sizes: StackSizeHelper
-    poe_session_id: str
-    account_name: str
+    poe_session_id: Union[str | None]
+    account_name: Union[str | None]
 
     def __init__(self,
                  version: int,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4,12 +4,14 @@ import json
 
 
 class UserConfigTest(unittest.TestCase):
-    def test_load_default_user_confg_from_fs(self):
-        user_config = UserConfig.from_file(DEFAULT_CONFIG_DEFAULT_FILE_PATH)
-        self.assert_is_user_config(user_config)
-
-    def test_load_user_confg_with_correct_defaults(self):
-        raw = {"version": 1, "trading": {"Chaos Orb": {}}, "assets": {}}
+    def test_deserialize_user_config_with_correct_defaults(self):
+        raw = {
+            "version": 1,
+            "trading": {
+                "Chaos Orb": {}
+            },
+            "assets": {},
+        }
         raw = json.dumps(raw)
         user_config = UserConfig.from_raw(raw)
         self.assert_is_user_config(user_config)
@@ -19,7 +21,38 @@ class UserConfigTest(unittest.TestCase):
         assert (x.maximum_stock != 0)
         assert (type(x.sell_for) is dict)
 
-    def assert_is_user_config(self, obj):
+        self.assertEqual(user_config.poe_session_id, None)
+        self.assertEqual(user_config.account_name, None)
+
+    def test_deserialize_user_config(self):
+        raw = {
+            "version": 1,
+            "trading": {
+                "Chaos Orb": {}
+            },
+            "assets": {},
+            "POESESSID": "123",
+            "accountName": "herpderp"
+        }
+        raw = json.dumps(raw)
+        user_config = UserConfig.from_raw(raw)
+        self.assert_is_user_config(user_config)
+
+        x = user_config.trading["Chaos Orb"]
+        assert (x.minimum_stock == 0)
+        assert (x.maximum_stock != 0)
+        assert (type(x.sell_for) is dict)
+
+        self.assertEqual(user_config.poe_session_id, "123")
+        self.assertEqual(user_config.account_name, "herpderp")
+
+    def test_load_default_user_config_from_file(self):
+        user_config = UserConfig.from_file(DEFAULT_CONFIG_DEFAULT_FILE_PATH)
+        self.assert_is_user_config(user_config)
+
+    def assert_is_user_config(self, obj: UserConfig):
         assert (hasattr(obj, "version"))
         assert (hasattr(obj, "trading"))
         assert (hasattr(obj, "assets"))
+        assert (hasattr(obj, "poe_session_id"))
+        assert (hasattr(obj, "account_name"))


### PR DESCRIPTION
Adds a new CLI command that syncs the `assets` section of a user's configuration with its actual public stash assets via using a user-provided `POESESSID` and `accountName` in said configuration file.

- [x] Extend config file to contain account credentials
  - accountName
  - POESESSID
- [x] Add a new CLI command
  - have separate commands
  - default to regular command
- [x] need league option for sync to call window API
- [x] Client to interact with stash-window
  - make http call
  - parse & aggregate results
    - no aggregation for now, because we only use the currency stash
- [x] find a nice way to feed parsed data into config file
- [x] Add documentation of the command
- [x] Add some docs on how to get the POESESSID

