### PR TITLE
items: use pathlib for assets/items.json

### DIFF
--- a/src/trading/items.py
+++ b/src/trading/items.py
@@ -20,6 +20,7 @@ import requests
 from typing import List, Dict, Tuple, Any
 import itertools
 import os
+from pathlib import Path
 import attr
 import json
 import deserialize
@@ -89,8 +90,7 @@ class ItemList:
     @staticmethod
     def load_from_file(path: str = None) -> ItemList:
         if path is None:
-            path = os.path.dirname(
-                os.path.abspath(__file__)) + "/../../assets/items.json"
+            path = Path(__file__).parent.parent.parent.absolute() / "assets/items.json"
 
         with open(path, "r") as f:
             item_list_json = json.load(f)


### PR DESCRIPTION
pathlib is available since 3.4, so I think this should be fine.
